### PR TITLE
get market by token example

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -9,6 +9,7 @@
         "getBalances": "ts-node src/get_balances.ts",
         "getMarketsByStatus": "ts-node src/get_markets_by_status.ts",
         "getMarketsByEvent": "ts-node src/get_markets_by_event.ts",
+        "getMarketsByMintToken": "ts-node src/get_markets_by_mint_token.ts",
         "getMarketPrices": "ts-node src/get_market_prices.ts",
         "getMarketPosition": "ts-node src/get_market_position.ts",
         "getBetOrders": "ts-node src/get_bet_orders_by_status.ts",

--- a/examples/cli/src/get_markets_by_mint_token.ts
+++ b/examples/cli/src/get_markets_by_mint_token.ts
@@ -1,0 +1,18 @@
+import { getMarketAccountsByStatusAndMintAccount, MarketStatus } from "@betdexlabs/betdex-client";
+import { PublicKey } from "@solana/web3.js";
+import { getProgram, logJson, log } from "./utils";
+
+async function getMarkets(marketStatus: MarketStatus, mintToken: PublicKey){
+    const program = await getProgram()
+    const markets = await getMarketAccountsByStatusAndMintAccount(program, marketStatus, mintToken)
+    if (!markets.success){
+        log(markets.errors)
+    }
+    else{
+        logJson(markets)
+    }
+}
+
+const mintToken = new PublicKey("Qegj89Mzpx4foJJqkj6B4551aiGrgaV33Dtcm7WZ9kf")
+const marketStatus = MarketStatus.Open
+getMarkets(marketStatus, mintToken)


### PR DESCRIPTION
- Filtering markets by mint token (the token you can bet with) is incredibly useful
- Adding an example on how to do that, using the beta token as an example