### PR TITLE
allow cli examples to accept arguments

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -15,7 +15,7 @@
         "getMarketOutcomeTitles": "ts-node src/get_market_outcome_titles.ts",
         "getMarketPrices": "ts-node src/get_market_prices.ts",
         "getMarketPosition": "ts-node src/get_market_position.ts",
-        "getOrders": "ts-node src/get_orders_by_status.ts",
+        "getOrdersByStatus": "ts-node src/get_orders_by_status.ts",
         "getOrder": "ts-node src/get_order.ts",
         "getMarketAccounts": "ts-node src/get_market_accounts.ts",
         "getMarketOutcomeAccounts": "ts-node src/get_market_outcome_accounts.ts",

--- a/examples/cli/src/cancel_order.ts
+++ b/examples/cli/src/cancel_order.ts
@@ -1,6 +1,6 @@
 import { cancelOrder } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function cancelOrderbyPk(orderPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function cancelOrderbyPk(orderPk: PublicKey){
     }
 }
 
-const orderPk = new PublicKey("Fy7WiqBy6MuWfnVjiPE8HQqkeLnyaLwBsk8cyyJ5WD8X")
+const processArgs = getProcessArgs(["orderPk"], "npm run cancelOrder")
+const orderPk = new PublicKey(processArgs.orderPk)
 cancelOrderbyPk(orderPk)

--- a/examples/cli/src/cancel_orders_for_market.ts
+++ b/examples/cli/src/cancel_orders_for_market.ts
@@ -1,6 +1,6 @@
 import { cancelOrdersForMarket } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function cancelOrders(marketPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function cancelOrders(marketPk: PublicKey){
     }
 }
 
-const marketPk = new PublicKey("4R6w8Q52jjnXdJB26K9ML9zUSzthscP3EWhvNZ2WyiAS")
+const processArgs = getProcessArgs(["marketPk"], "npm run cancelOrders")
+const marketPk = new PublicKey(processArgs.marketPk)
 cancelOrders(marketPk)

--- a/examples/cli/src/get_balances.ts
+++ b/examples/cli/src/get_balances.ts
@@ -1,6 +1,6 @@
 import { getWalletTokenBalancesWithSol } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function getBalances(tokenMints: PublicKey[]){
     const program = await getProgram()
@@ -15,4 +15,5 @@ async function getBalances(tokenMints: PublicKey[]){
 
 const exampleTokenMint1 = new PublicKey("Qegj89Mzpx4foJJqkj6B4551aiGrgaV33Dtcm7WZ9kf")
 const exampleTokenMint2 = new PublicKey("Aqw6KyChFm2jwAFND3K29QjUcKZ3Pk72ePe5oMxomwMH")
+getProcessArgs([], "npm run getBalances")
 getBalances([exampleTokenMint1, exampleTokenMint2])

--- a/examples/cli/src/get_market.ts
+++ b/examples/cli/src/get_market.ts
@@ -1,6 +1,6 @@
 import { getMarket } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function getMarketByPk(marketPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function getMarketByPk(marketPk: PublicKey){
     }
 }
 
-const marketPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
+const processArgs = getProcessArgs(["marketPk"], "npm run getMarket")
+const marketPk = new PublicKey(processArgs.marketPk)
 getMarketByPk(marketPk)

--- a/examples/cli/src/get_market_accounts.ts
+++ b/examples/cli/src/get_market_accounts.ts
@@ -1,6 +1,6 @@
 import { getMarketAccounts } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function getAllMarketAccounts(
     marketPk: PublicKey,
@@ -24,5 +24,9 @@ async function getAllMarketAccounts(
     }
 }
 
-const marketPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
-getAllMarketAccounts(marketPk, false, 0, 3)
+const processArgs = getProcessArgs(["marketPk", "forOutcome", "marketOutcomeIndex", "price"], "npm run getMarketAccounts")
+const marketPk = new PublicKey(processArgs.marketPk)
+const forOutcome = processArgs.forOutcome === "true"
+const marketOutcomeIndex = parseFloat(processArgs.marketOutcomeIndex)
+const price = parseFloat(processArgs.price)
+getAllMarketAccounts(marketPk, forOutcome, marketOutcomeIndex, price)

--- a/examples/cli/src/get_market_outcome_titles.ts
+++ b/examples/cli/src/get_market_outcome_titles.ts
@@ -1,6 +1,6 @@
 import { getMarketOutcomeTitlesByMarket } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function marketOutcomeTitles(marketPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function marketOutcomeTitles(marketPk: PublicKey){
     }
 }
 
-const marketPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
+const processArgs = getProcessArgs(["marketPk"], "npm run getMarketOutcomeTitles")
+const marketPk = new PublicKey(processArgs.marketPk)
 marketOutcomeTitles(marketPk)

--- a/examples/cli/src/get_market_outcomes.ts
+++ b/examples/cli/src/get_market_outcomes.ts
@@ -1,6 +1,6 @@
 import { getMarketOutcomesByMarket } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function marketOutcomes(marketPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function marketOutcomes(marketPk: PublicKey){
     }
 }
 
-const marketPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
+const processArgs = getProcessArgs(["marketPk"], "npm run getMarketOutcomes")
+const marketPk = new PublicKey(processArgs.marketPk)
 marketOutcomes(marketPk)

--- a/examples/cli/src/get_market_position.ts
+++ b/examples/cli/src/get_market_position.ts
@@ -1,6 +1,6 @@
 import { getMarketPosition } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 import { AnchorProvider } from "@project-serum/anchor";
 
 async function getMarketPositionForProvider(marketPk: PublicKey){
@@ -15,5 +15,6 @@ async function getMarketPositionForProvider(marketPk: PublicKey){
     }
 }
 
-const eventPk = new PublicKey("4R6w8Q52jjnXdJB26K9ML9zUSzthscP3EWhvNZ2WyiAS")
-getMarketPositionForProvider(eventPk)
+const processArgs = getProcessArgs(["marketPk"], "npm run getMarketPosition")
+const marketPk = new PublicKey(processArgs.marketPk)
+getMarketPositionForProvider(marketPk)

--- a/examples/cli/src/get_market_prices.ts
+++ b/examples/cli/src/get_market_prices.ts
@@ -1,6 +1,6 @@
 import { getMarketPrices } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs} from "./utils";
 
 async function getMarketPricesByPk(marketPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function getMarketPricesByPk(marketPk: PublicKey){
     }
 }
 
-const eventPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
-getMarketPricesByPk(eventPk)
+const processArgs = getProcessArgs(["marketPk"], "npm run getMarketPrices")
+const marketPk = new PublicKey(processArgs.marketPk)
+getMarketPricesByPk(marketPk)

--- a/examples/cli/src/get_markets_by_event.ts
+++ b/examples/cli/src/get_markets_by_event.ts
@@ -1,6 +1,6 @@
 import { getMarketAccountsByEvent } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function getMarkets(eventAccountPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function getMarkets(eventAccountPk: PublicKey){
     }
 }
 
-const eventPk = new PublicKey("1aKQHeedwwMiyqDXC7wZzhRdp2qUmxpbVWMbuwhYpwT")
+const processArgs = getProcessArgs(["eventPk"], "npm run getMarketsByEvent")
+const eventPk = new PublicKey(processArgs.eventPk)
 getMarkets(eventPk)

--- a/examples/cli/src/get_markets_by_mint_token.ts
+++ b/examples/cli/src/get_markets_by_mint_token.ts
@@ -1,8 +1,8 @@
 import { getMarketAccountsByStatusAndMintAccount, MarketStatus } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs, marketStatusFromString } from "./utils";
 
-async function getMarkets(marketStatus: MarketStatus, mintToken: PublicKey){
+async function getMarkets(mintToken: PublicKey, marketStatus: MarketStatus){
     const program = await getProgram()
     const markets = await getMarketAccountsByStatusAndMintAccount(program, marketStatus, mintToken)
     if (!markets.success){
@@ -13,6 +13,8 @@ async function getMarkets(marketStatus: MarketStatus, mintToken: PublicKey){
     }
 }
 
-const mintToken = new PublicKey("Aqw6KyChFm2jwAFND3K29QjUcKZ3Pk72ePe5oMxomwMH")
-const marketStatus = MarketStatus.Open
-getMarkets(marketStatus, mintToken)
+// The Monaco Protocol example token: Aqw6KyChFm2jwAFND3K29QjUcKZ3Pk72ePe5oMxomwMH
+const processArgs = getProcessArgs(["mintToken", "marketStatus"], "npm run getMarketsByMintToken")
+const mintToken = new PublicKey(processArgs.mintToken)
+const marketStatus = marketStatusFromString(processArgs.marketStatus)
+getMarkets(mintToken, marketStatus)

--- a/examples/cli/src/get_markets_by_status.ts
+++ b/examples/cli/src/get_markets_by_status.ts
@@ -1,5 +1,5 @@
 import { getMarketAccountsByStatus, MarketStatus } from "@monaco-protocol/client";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs, marketStatusFromString } from "./utils";
 
 async function getMarkets(status: MarketStatus){
     const program = await getProgram()
@@ -12,4 +12,6 @@ async function getMarkets(status: MarketStatus){
     }
 }
 
-getMarkets(MarketStatus.Open)
+const processArgs = getProcessArgs(["marketStatus"], "npm run getMarketsByStatus")
+const marketStatus = marketStatusFromString(processArgs.marketStatus)
+getMarkets(marketStatus)

--- a/examples/cli/src/get_order.ts
+++ b/examples/cli/src/get_order.ts
@@ -1,6 +1,6 @@
 import { getOrder } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function getBetOrderbyPk(betOrderPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function getBetOrderbyPk(betOrderPk: PublicKey){
     }
 }
 
-const betOrderPk = new PublicKey("Fy7WiqBy6MuWfnVjiPE8HQqkeLnyaLwBsk8cyyJ5WD8X")
+const processArgs = getProcessArgs(["betOrderPk"], "npm run getOrder")
+const betOrderPk = new PublicKey(processArgs.betOrderPk)
 getBetOrderbyPk(betOrderPk)

--- a/examples/cli/src/get_orders_by_status.ts
+++ b/examples/cli/src/get_orders_by_status.ts
@@ -1,5 +1,5 @@
 import { getOrdersByStatusForProviderWallet, OrderStatus } from "@monaco-protocol/client";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs, orderStatusFromString } from "./utils";
 
 async function getBetOrders(status: OrderStatus){
     const program = await getProgram()
@@ -12,4 +12,6 @@ async function getBetOrders(status: OrderStatus){
     }
 }
 
-getBetOrders(OrderStatus.Open)
+const processArgs = getProcessArgs(["orderStatus"], "npm run getOrdersByStatus")
+const orderStatus = orderStatusFromString(processArgs.orderStatus)
+getBetOrders(orderStatus)

--- a/examples/cli/src/get_trades_for_market.ts
+++ b/examples/cli/src/get_trades_for_market.ts
@@ -1,6 +1,6 @@
 import { getTradesForMarket } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function getTrades(marketPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function getTrades(marketPk: PublicKey){
     }
 }
 
-const marketPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
+const processArgs = getProcessArgs(["marketPk"], "npm run getTradesForMarket")
+const marketPk = new PublicKey(processArgs.marketPk)
 getTrades(marketPk)

--- a/examples/cli/src/get_trades_for_order.ts
+++ b/examples/cli/src/get_trades_for_order.ts
@@ -1,6 +1,6 @@
 import { getTradesForOrder } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function getTrades(marketPk: PublicKey){
     const program = await getProgram()
@@ -13,5 +13,6 @@ async function getTrades(marketPk: PublicKey){
     }
 }
 
-const orderPk = new PublicKey("Ergn5AUNWpfwKbhFm82Ja9ZGDfmizcyKy7QS4Ur1piJG")
-getTrades(orderPk)
+const processArgs = getProcessArgs(["betOrderPk"], "npm run getTradesForOrder")
+const betOrderPk = new PublicKey(processArgs.betOrderPk)
+getTrades(betOrderPk)

--- a/examples/cli/src/place_against_order.ts
+++ b/examples/cli/src/place_against_order.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import { createOrderUiStake } from "@monaco-protocol/client";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function placeOrder(marketPk: PublicKey){
     const program = await getProgram()
@@ -17,5 +17,6 @@ async function placeOrder(marketPk: PublicKey){
     }
 }
 
-const marketPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
+const processArgs = getProcessArgs(["marketPk"], "npm run placeForOrder")
+const marketPk = new PublicKey(processArgs.marketPk)
 placeOrder(marketPk)

--- a/examples/cli/src/place_for_order.ts
+++ b/examples/cli/src/place_for_order.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import { createOrderUiStake } from "@monaco-protocol/client";
-import { getProgram, logJson, log } from "./utils";
+import { getProgram, logJson, log, getProcessArgs } from "./utils";
 
 async function placeOrder(marketPk: PublicKey){
     const program = await getProgram()
@@ -17,5 +17,6 @@ async function placeOrder(marketPk: PublicKey){
     }
 }
 
-const marketPk = new PublicKey("CCJqgUHtTZcMtkjAuqJuTJoRA78gWpgeRRtbt7tNcZVi")
+const processArgs = getProcessArgs(["marketPk"], "npm run placeAgainstOrder")
+const marketPk = new PublicKey(processArgs.marketPk)
 placeOrder(marketPk)

--- a/examples/cli/src/utils.ts
+++ b/examples/cli/src/utils.ts
@@ -1,6 +1,6 @@
 import { PublicKey } from "@solana/web3.js";
 import { AnchorProvider, setProvider, Program } from "@project-serum/anchor";
-import { ProtocolAddresses } from "@monaco-protocol/client";
+import { ProtocolAddresses, MarketStatus, OrderStatus } from "@monaco-protocol/client";
 
 export async function getProgram() {
   const provider = AnchorProvider.env();
@@ -16,4 +16,57 @@ export function log(log: any){
 
 export function logJson(json: object){
   console.log(JSON.stringify(json, null, 2))
+}
+
+export function getProcessArgs(expectedArgs: string[], exampleInvocation: string): any{
+  const defaultArgLength = 2
+  if (process.argv.length != defaultArgLength+expectedArgs.length) {
+    console.log(
+      `Expected number of args: ${expectedArgs.length}\n` +
+      `Example invocation: ${exampleInvocation} ${expectedArgs.toString().replace(/,/g, ' ')}`
+    );
+    process.exit(1);
+  }
+  const namedArgs = process.argv.slice(-expectedArgs.length)
+  let values = {}
+  expectedArgs.map(function (arg, i){
+    return values[expectedArgs[i]] = namedArgs[i]
+  })
+  log("Supplied arguments:")
+  logJson(values)
+  return values
+}
+
+export function marketStatusFromString(status: string){
+  switch (status){
+    case "open":
+      return MarketStatus.Open
+    case "locked":
+      return MarketStatus.Locked
+    case "settled":
+      return MarketStatus.Settled
+    case "complete":
+      return MarketStatus.Complete
+    case "readyForSettlement":
+      return MarketStatus.ReadyForSettlement
+    default:
+      throw "Available market statuses: open, locked, settled, complete, readyForSettlement"
+  }
+}
+
+export function orderStatusFromString(status: string){
+  switch (status){
+    case "open":
+      return OrderStatus.Open  
+    case "matched":
+      return OrderStatus.Matched 
+    case "settledWin":
+      return OrderStatus.SettledWin  
+    case "settledLose":
+      return OrderStatus.SettledLose  
+    case "cancelled":
+      return OrderStatus.Cancelled  
+    default:
+      throw "Available order statuses: open, matched, settledWin, settledLose, cancelled" 
+  }
 }


### PR DESCRIPTION
Previously example cli scripts included hardcoded example arguments. There was no guarantee that these arguments would related to valid on-chain accounts. 

- This change brings in a helper `getProcessArgs` pull in the arguments from the command line and offer examples where the required arguments are missing.

```
npm run getMarketsByStatus

> @monaco-protocol/examples@1.0.0 getMarketsByStatus
> ts-node src/get_markets_by_status.ts

Expected number of args: 1
Example invocation: npm run getMarketsByStatus marketStatus
```

- Where types are required (MarketStatus and OrderStatus) an exception is thrown if an invalid string representation of the status is passed.

```
npm run getMarketsByStatus openStatus

> @monaco-protocol/examples@1.0.0 getMarketsByStatus
> ts-node src/get_markets_by_status.ts openStatus

Supplied arguments:
{
  "marketStatus": "openStatus"
}
'Available market statuses: open, locked, settled, complete, readyForSettlement'
```

- Get market example

```
npm run getMarket 2fNQSVErscL73n6KQjGKEJfR9Y4VEVGGnhgYd5CHUffQ

> @monaco-protocol/examples@1.0.0 getMarket
> ts-node src/get_market.ts 2fNQSVErscL73n6KQjGKEJfR9Y4VEVGGnhgYd5CHUffQ

Supplied arguments:
{
  "marketPk": "2fNQSVErscL73n6KQjGKEJfR9Y4VEVGGnhgYd5CHUffQ"
}
{
  "success": true,
  "errors": [],
  "data": {
    "publicKey": "2fNQSVErscL73n6KQjGKEJfR9Y4VEVGGnhgYd5CHUffQ",
    "account": {
      "authority": "98CVwMftrhm6zutmV29frqRPfXsocbFnwjXVxYo7xbHX",
      "eventAccount": "22a7Kzm25SVJne7Sk5truug29ZrA4tdFgoxQm3PKJ4kN",
      "mintAccount": "2QqxXa2aNCx3DLQCHgiC4P7Xfbe3B4bULM5eKpyAirGY",
      "marketStatus": {
        "open": {}
      },
      "marketType": "EventResultFullTime",
      "decimalLimit": 3,
      "published": false,
      "suspended": false,
      "marketOutcomesCount": 3,
      "marketWinningOutcomeIndex": null,
      "marketLockTimestamp": "72b1c956",
      "marketSettleTimestamp": null,
      "title": "Example Market",
      "escrowAccountBump": 255
    }
  }
}
```