### PR TITLE
Load open markets in nextjs example

### DIFF
--- a/examples/nextjs/pages/index.tsx
+++ b/examples/nextjs/pages/index.tsx
@@ -1,11 +1,32 @@
+import { useEffect, useState } from 'react'
 import type { NextPage } from 'next'
-import { Card, Link as MuiLink } from '@mui/material'
+import { Card, Link as MuiLink, Skeleton } from '@mui/material'
 import Head from 'next/head'
 import Link from 'next/link'
+import { getMarketAccountsByStatus, MarketStatus } from '@monaco-protocol/client'
+import { PublicKey } from "@solana/web3.js"
 import { Page } from '../components/Page'
+import { useProgram } from '../context/ProgramProvider'
 
 const Home: NextPage = () => {
-  const marketAccount = "4R6w8Q52jjnXdJB26K9ML9zUSzthscP3EWhvNZ2WyiAS"
+  const program = useProgram();
+  const [marketAccount, setMarketAccount] = useState<PublicKey>();
+
+  useEffect(() => {
+    const getOpenMarketAccount = async () => {
+      const res = await getMarketAccountsByStatus(program, MarketStatus.Open);
+
+      // Only get an open market with a non-zero marketOutcomesCount
+      res.data.markets.forEach(market => {
+        if (market.account.marketOutcomesCount !== 0) {
+          setMarketAccount(market.publicKey);
+          return;
+        }
+      });
+    }
+    getOpenMarketAccount().catch(console.error);
+  }, []);
+
   return (
     <Page
       title="NextJS Monaco Protocol"
@@ -16,27 +37,37 @@ const Home: NextPage = () => {
         <meta name="description" content="Example usage of the protocol" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+
       <Card sx={{
         padding: '1rem',
       }}>
-        <ul>
-          <li>
-            <Link href={`/markets/${marketAccount}/my-bets`}>
-              <MuiLink>
-                My bets
-              </MuiLink>
-            </Link>
-          </li>
-          <li>
-            <Link href={`/markets/${marketAccount}/place-bet`}>
+        {marketAccount === undefined 
+          ? (
+            <>
+            <Skeleton variant="text" sx={{ fontSize: '1rem', width: "30%" }} />
+            <Skeleton variant="text" sx={{ fontSize: '1rem', width: "30%" }} />
+            </>
+          )
+          :
+          <ul>
+            <li>
+              <Link href={`/markets/${marketAccount.toBase58()}/my-bets`}>
                 <MuiLink>
-                  Place bet
+                  My bets
                 </MuiLink>
               </Link>
-          </li>
-        </ul>
-        </Card>
-      </Page>
+            </li>
+            <li>
+              <Link href={`/markets/${marketAccount.toBase58()}/place-bet`}>
+                  <MuiLink>
+                    Place bet
+                  </MuiLink>
+                </Link>
+            </li>
+          </ul>
+        }
+      </Card>
+    </Page>
   )
 }
 

--- a/examples/nextjs/pages/markets/[marketAccount]/place-bet.tsx
+++ b/examples/nextjs/pages/markets/[marketAccount]/place-bet.tsx
@@ -12,7 +12,19 @@ import { PublicKey } from "@solana/web3.js";
 import { useRouter } from "next/router";
 import React, { useEffect, useState } from "react";
 import { useProgram } from "../../../context/ProgramProvider";
-import { Box, Button, Card, Divider, FormControl, FormControlLabel, FormLabel, InputLabel, MenuItem, Radio, RadioGroup, Select, TextField, Typography } from "@mui/material";
+import { 
+    Box, 
+    Button, 
+    Card, 
+    CircularProgress, 
+    Divider, 
+    FormControl, FormControlLabel, FormLabel, InputLabel, 
+    MenuItem, 
+    Radio, RadioGroup, 
+    Select, 
+    TextField, 
+    Typography,
+} from "@mui/material";
 import { BN } from "@project-serum/anchor";
 import { Page } from "../../../components/Page";
 import { useWallet } from "@solana/wallet-adapter-react";
@@ -109,6 +121,7 @@ const PlaceBet = () => {
             title="Place Bet Example"
             description="Example of how to get the required data to construct a bet order and how to exexute it."
         >
+            <Typography variant="h4">{market?.account.title}</Typography>
             <Card sx={{
                 padding: '3rem 1rem',
                 display: 'flex',
@@ -118,6 +131,10 @@ const PlaceBet = () => {
                     lg: 'row',
                 }
             }}>
+            
+            {!formData && (
+                <CircularProgress sx={{ ml: "50%" }} />
+            )}
 
             {formData && marketOutcomes?.map(({ account: { title }}, marketOutcomeIndex) =>
                 (
@@ -194,7 +211,6 @@ const PlaceBet = () => {
             </Card>
         </Page>
     );
-
 }
 
 export default PlaceBet;


### PR DESCRIPTION
**Issue:** 

Nextjs example wasn't loading any open markets as the query for market account was hardcoded and invalid

**Solution:**

1. Calls `getMarketAccountsByStatus` and loads an open market that has a non-zero market outcome count.
2. Adds loading states to index and place-bet pages.