### PR TITLE
return outcome titles in table

### DIFF
--- a/examples/cli/src/get_market_outcome_titles.ts
+++ b/examples/cli/src/get_market_outcome_titles.ts
@@ -5,7 +5,7 @@ import { getProgram, getProcessArgs, logResponse } from "./utils";
 async function marketOutcomeTitles(marketPk: PublicKey){
     const program = await getProgram()
     const response = await getMarketOutcomeTitlesByMarket(program, marketPk)
-    logResponse(response)
+    console.table(response.data.marketOutcomeTitles)
 }
 
 const args = getProcessArgs(["marketPk"], "npm run getMarketOutcomeTitles")


### PR DESCRIPTION
- On `npm run getMarketOutcomeTitles <marketPk>`
- Return outcome titles as a table so as to display the index

![image](https://user-images.githubusercontent.com/11299576/210547142-60caad98-ddd8-4851-86f6-60c9f0f04e5d.png)
