### PR TITLE
Account parsing examples and get orders for market by status

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -18,6 +18,7 @@
         "getOrdersByStatus": "ts-node src/get_orders_by_status.ts",
         "getOrder": "ts-node src/get_order.ts",
         "getMarketAccounts": "ts-node src/get_market_accounts.ts",
+        "getMarketSummary": "ts-node src/get_market_summary.ts",
         "getMarketOutcomeAccounts": "ts-node src/get_market_outcomes.ts",
         "getTradesForMarket": "ts-node src/get_trades_for_market.ts",
         "getTradesForOrder": "ts-node src/get_trades_for_order.ts",

--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -16,6 +16,7 @@
         "getMarketPrices": "ts-node src/get_market_prices.ts",
         "getMarketPosition": "ts-node src/get_market_position.ts",
         "getOrdersByStatus": "ts-node src/get_orders_by_status.ts",
+        "getOrdersForMarketByStatus": "ts-node src/get_orders_for_market_by_status.ts",
         "getOrder": "ts-node src/get_order.ts",
         "getMarketAccounts": "ts-node src/get_market_accounts.ts",
         "getMarketSummary": "ts-node src/get_market_summary.ts",

--- a/examples/cli/src/get_market_summary.ts
+++ b/examples/cli/src/get_market_summary.ts
@@ -1,98 +1,47 @@
-import { getMarketPrices, getMintInfo, MarketOutcomeAccount, MarketPrice, MarketPricesAndPendingOrders } from "@monaco-protocol/client";
+import { getMarketPrices, getMintInfo, MarketOutcomeAccount, MarketPrice, MarketPricesAndPendingOrders, Order } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { parseMarketOutcomeAccount } from "./parsers/market_outcome_parser";
-import { parseMarketAccount } from "./parsers/market_parser";
-import { parseMarketPrice } from "./parsers/market_price_parser";
-import { parseOrderAccount } from "./parsers/order_parser";
+import { mapPricesToOutcomesAndForAgainst } from "./mappers/market_price_mapper";
+import { mapOrdersToOutcomesAndForAgainst } from "./mappers/order_mapper";
+import { parseMarketPricesAndPendingOrders } from "./parsers/market_prices_and_pending_orders";
 import { getProgram, getProcessArgs, logJson } from "./utils";
 
 async function getMarketSummary(marketPk: PublicKey){
     const program = await getProgram()
     const response = await getMarketPrices(program, marketPk)
     const mintDetails = await getMintInfo(program, response.data.market.mintAccount)
-    const parsedMarketPrices = parseMarketPricesResponse(response.data, mintDetails.data.decimals, true, true)
+    const parsedMarketPrices = parseMarketPricesAndPendingOrders(response.data, mintDetails.data.decimals, true, true)
     const marketOutcomeAccounts =  parsedMarketPrices.marketOutcomeAccounts.map((marketOutcomeAccount) => {
         return marketOutcomeAccount.account
     })
     const matchedTotal = matchedTotalFromParsedOutcomeAccounts(marketOutcomeAccounts)
     const liquidityTotal = liquidityTotalFromParsedMarketPrices(parsedMarketPrices.marketPrices)
-    const marketOutcomesSummary = parsedMarketPrices.marketOutcomeAccounts.map((outcome) => {
-        return {
-            outcome: outcome.account.title,
+    const marketOutcomesSummary = {}
+    parsedMarketPrices.marketOutcomeAccounts.map((outcome) => {
+        marketOutcomesSummary[outcome.account.title] = {
             latestMatchedPrice: outcome.account.latestMatchedPrice,
             matchedTotal: outcome.account.matchedTotal
         }
     })
 
-    const forAndAgainst = [true, false]
+    const outcomeTitles = marketOutcomeAccounts.map((outcome) => {return outcome.title})
+    const pendingOrders = parsedMarketPrices.pendingOrders.map((order) => {return order.account})
 
-    const pendingOrderSummary = {}
-    parsedMarketPrices.marketOutcomeAccounts.map((outcome) => {
-        pendingOrderSummary[outcome.account.title] = forAndAgainst.map((forAgainst) => {
-            let forAgainstSummary = {}
-            const filteredOrders = parsedMarketPrices.pendingOrders.filter((pendingOrder) => pendingOrder.account.forOutcome === forAgainst && pendingOrder.account.marketOutcomeIndex === outcome.account.index)
-            let forOrAgainst = "Against"
-            if (forAgainst) forOrAgainst = "For"
-            forAgainstSummary[forOrAgainst] = filteredOrders.map((filteredOrder) => {
-                return {
-                    stake: filteredOrder.account.stake,
-                    price: filteredOrder.account.expectedPrice
-                }
-            })
-            return forAgainstSummary
-        })
-    })
-    const pendingOrderSummary2 = parsedMarketPrices.pendingOrders.map((pendingOrder) => {
-        return {
-            outcome: parsedMarketPrices.marketOutcomeAccounts[pendingOrder.account.marketOutcomeIndex].account.title,
-            forOutcome: pendingOrder.account.forOutcome,
-            stake: pendingOrder.account.stake,
-            expectedPrice: pendingOrder.account.expectedPrice
-        }
-    })
+    const pendingOrderSummary = mapOrdersToOutcomesAndForAgainst(outcomeTitles, pendingOrders)
+    const marketPriceSummary = mapPricesToOutcomesAndForAgainst(outcomeTitles, parsedMarketPrices.marketPrices)
 
-    const marketPriceSummary = {}
-    parsedMarketPrices.marketOutcomeAccounts.map((outcome) => {
-        marketPriceSummary[outcome.account.title] = forAndAgainst.map((forAgainst) => {
-            let forAgainstSummary = {}
-            const filteredPrices = parsedMarketPrices.marketPrices.filter((marketPrice) => marketPrice.forOutcome === forAgainst && marketPrice.marketOutcome == outcome.account.title)
-            let forOrAgainst = "Against"
-            if (forAgainst) forOrAgainst = "For"
-            forAgainstSummary[forOrAgainst] = filteredPrices.map((filteredPrice) => {
-                return {
-                    price: filteredPrice.price,
-                    liquidity: filteredPrice.matchingPool.liquidityAmount
-                }
-            })
-            return forAgainstSummary
-        })
-    })
     logJson(
         {
             pendingOrderSummary: pendingOrderSummary,
             marketPriceSummary: marketPriceSummary,
+            marketOutcomesSummary: marketOutcomesSummary,
             marketTitle: parsedMarketPrices.market.title,
             marketLock: new Date(parsedMarketPrices.market.marketLockTimestamp * 1000),
             liquidityTotal: liquidityTotal,
             matchedTotal: matchedTotal,
-            marketOutcomesSummary: marketOutcomesSummary,
-            totalUnmatchedOrders: parsedMarketPrices.pendingOrders.length
+            totalUnmatchedOrders: parsedMarketPrices.pendingOrders.length,
+            test: pendingOrderSummary[0]
         }
     )
-}
-
-export function parseMarketPricesResponse(marketPricesAndPendingOrders: MarketPricesAndPendingOrders, mintDecimals: number, reduceLadder: boolean = true, onlyShowOrdersInQueue: boolean = true){
-    marketPricesAndPendingOrders.market = parseMarketAccount(marketPricesAndPendingOrders.market)
-    marketPricesAndPendingOrders.marketOutcomeAccounts.map((marketOutcomeAccount) => {
-        marketOutcomeAccount.account = parseMarketOutcomeAccount(marketOutcomeAccount.account, mintDecimals, reduceLadder)
-    })
-    marketPricesAndPendingOrders.marketPrices.map((marketPrices) => {
-        marketPrices = parseMarketPrice(marketPrices, mintDecimals, onlyShowOrdersInQueue)
-    })
-    marketPricesAndPendingOrders.pendingOrders.map(order => {
-        order.account = parseOrderAccount(order.account, mintDecimals)
-    })
-    return marketPricesAndPendingOrders
 }
 
 function matchedTotalFromParsedOutcomeAccounts(marketOutcomeAccounts: MarketOutcomeAccount[]){

--- a/examples/cli/src/get_market_summary.ts
+++ b/examples/cli/src/get_market_summary.ts
@@ -1,0 +1,88 @@
+import { getMarketPrices, getMintInfo, MarketOutcomeAccount, MarketPrice, MarketPricesAndPendingOrders } from "@monaco-protocol/client";
+import { PublicKey } from "@solana/web3.js";
+import { parseMarketOutcomeAccount } from "./parsers/market_outcome_parser";
+import { parseMarketAccount } from "./parsers/market_parser";
+import { parseMarketPrice } from "./parsers/market_price_parser";
+import { parseOrderAccount } from "./parsers/order_parser";
+import { getProgram, getProcessArgs, logJson } from "./utils";
+
+async function getMarketSummary(marketPk: PublicKey){
+    const program = await getProgram()
+    const response = await getMarketPrices(program, marketPk)
+    const mintDetails = await getMintInfo(program, response.data.market.mintAccount)
+    const parsedMarketPrices = parseMarketPricesResponse(response.data, mintDetails.data.decimals, true, true)
+    const marketOutcomeAccounts =  parsedMarketPrices.marketOutcomeAccounts.map((marketOutcomeAccount) => {
+        return marketOutcomeAccount.account
+    })
+    const matchedTotal = matchedTotalFromParsedOutcomeAccounts(marketOutcomeAccounts)
+    const liquidityTotal = liquidityTotalFromParsedMarketPrices(parsedMarketPrices.marketPrices)
+    const marketOutcomesSummary = parsedMarketPrices.marketOutcomeAccounts.map((outcome) => {
+        return {
+            outcome: outcome.account.title,
+            latestMatchedPrice: outcome.account.latestMatchedPrice,
+            matchedTotal: outcome.account.matchedTotal
+        }
+    })
+    const pendingOrderSummary = parsedMarketPrices.pendingOrders.map((pendingOrder) => {
+        return {
+            outcomeIndex: pendingOrder.account.marketOutcomeIndex,
+            forOutcome: pendingOrder.account.forOutcome,
+            stake: pendingOrder.account.stake,
+            expectedPrice: pendingOrder.account.expectedPrice
+        }
+    })
+    const marketPricesSummary = parsedMarketPrices.marketPrices.map((marketPrice) => {
+        return {
+            outcome: marketPrice.marketOutcome,
+            outcomeIndex: marketPrice.marketOutcomeIndex,
+            price: marketPrice.price,
+            forOutcome: marketPrice.forOutcome,
+            liquidity: marketPrice.matchingPool.liquidityAmount,
+        }
+    })
+    logJson(
+        {
+            pendingOrderSummary: pendingOrderSummary,
+            marketPriceSummary: marketPricesSummary,
+            marketTitle: parsedMarketPrices.market.title,
+            marketLock: new Date(parsedMarketPrices.market.marketLockTimestamp * 1000),
+            liquidityTotal: liquidityTotal,
+            matchedTotal: matchedTotal,
+            marketOutcomesSummary: marketOutcomesSummary,
+            totalUnmatchedOrders: parsedMarketPrices.pendingOrders.length,
+        }
+    )
+}
+
+export function parseMarketPricesResponse(marketPricesAndPendingOrders: MarketPricesAndPendingOrders, mintDecimals: number, reduceLadder: boolean = true, onlyShowOrdersInQueue: boolean = true){
+    marketPricesAndPendingOrders.market = parseMarketAccount(marketPricesAndPendingOrders.market)
+    marketPricesAndPendingOrders.marketOutcomeAccounts.map((marketOutcomeAccount) => {
+        marketOutcomeAccount.account = parseMarketOutcomeAccount(marketOutcomeAccount.account, mintDecimals, reduceLadder)
+    })
+    marketPricesAndPendingOrders.marketPrices.map((marketPrices) => {
+        marketPrices = parseMarketPrice(marketPrices, mintDecimals, onlyShowOrdersInQueue)
+    })
+    marketPricesAndPendingOrders.pendingOrders.map(order => {
+        order.account = parseOrderAccount(order.account, mintDecimals)
+    })
+    return marketPricesAndPendingOrders
+}
+
+function matchedTotalFromParsedOutcomeAccounts(marketOutcomeAccounts: MarketOutcomeAccount[]){
+    let marketMatchedTotal = 0
+    marketOutcomeAccounts.map((marketOutcome) => {
+        marketMatchedTotal += marketOutcome.matchedTotal
+    })
+    return marketMatchedTotal
+}
+
+function liquidityTotalFromParsedMarketPrices(marketPrices: MarketPrice[]){
+    let marketLiquidity = 0
+    marketPrices.map((marketPrice) => {
+        marketLiquidity += marketPrice.matchingPool.liquidityAmount
+    })
+    return marketLiquidity
+}
+
+const args = getProcessArgs(["marketPk"], "npm run getMarketSummary")
+getMarketSummary(new PublicKey(args.marketPk))

--- a/examples/cli/src/get_orders_for_market_by_status.ts
+++ b/examples/cli/src/get_orders_for_market_by_status.ts
@@ -1,0 +1,15 @@
+import { Orders, OrderStatus } from "@monaco-protocol/client";
+import { PublicKey } from "@solana/web3.js";
+import { getProgram, getProcessArgs, orderStatusFromString, logResponse } from "./utils";
+
+async function getBetOrders(marketPk: PublicKey, status: OrderStatus){
+    const program = await getProgram()
+    const response = await Orders.orderQuery(program)
+        .filterByMarket(marketPk)
+        .filterByStatus(status)
+        .fetch()
+    logResponse(response)
+}
+
+const args = getProcessArgs(["marketPk", "orderStatus"], "npm run getOrdersForMarketByStatus")
+getBetOrders(new PublicKey(args.marketPk), orderStatusFromString(args.orderStatus))

--- a/examples/cli/src/mappers/market_price_mapper.ts
+++ b/examples/cli/src/mappers/market_price_mapper.ts
@@ -1,0 +1,13 @@
+import { MarketPrice } from "@monaco-protocol/client"
+
+export function mapPricesToOutcomesAndForAgainst(outcomeTitles: string[], marketPrices: MarketPrice[]){
+    const mapping = outcomeTitles.map((outcomeTitle) => {
+        const forOutcome = marketPrices.filter((marketPrice) => marketPrice.forOutcome && marketPrice.marketOutcome === outcomeTitle)
+        const againstOutcome = marketPrices.filter((marketPrice) => !marketPrice.forOutcome && marketPrice.marketOutcome === outcomeTitle)
+        return {
+            for: forOutcome.map((price) => {return {outcome: outcomeTitle, stake: price.price, liquidity: price.matchingPool.liquidityAmount}}),
+            against: againstOutcome.map((price) => {return {outcome: outcomeTitle, stake: price.price, liquidity: price.matchingPool.liquidityAmount}}),
+        }
+    })
+    return mapping
+}

--- a/examples/cli/src/mappers/order_mapper.ts
+++ b/examples/cli/src/mappers/order_mapper.ts
@@ -1,0 +1,13 @@
+import { Order } from "@monaco-protocol/client"
+
+export function mapOrdersToOutcomesAndForAgainst(outcomeTitles: string[], orders: Order[]){
+    const mapping = outcomeTitles.map((outcomeTitle) => {
+        const forOutcome = orders.filter((order) => order.forOutcome && order.marketOutcomeIndex === outcomeTitles.indexOf(outcomeTitle))
+        const againstOutcome = orders.filter((order) => !order.forOutcome && order.marketOutcomeIndex === outcomeTitles.indexOf(outcomeTitle))
+        return {
+            for: forOutcome.map((order) => {return {outcome: outcomeTitle, expectedPrice: order.expectedPrice, stake: order.stake}}),
+            against: againstOutcome.map((order) => {return {outcome: outcomeTitle, expectedPrice: order.expectedPrice, stake: order.stake}})
+        }
+    })
+    return mapping
+}

--- a/examples/cli/src/parsers/market_outcome_parser.ts
+++ b/examples/cli/src/parsers/market_outcome_parser.ts
@@ -1,0 +1,13 @@
+import { MarketOutcomeAccount } from "@monaco-protocol/client";
+import { parseTokenAmountBN } from "./token_parser"
+
+export function parseMarketOutcomeAccount(marketOutcomeAccount: MarketOutcomeAccount, mintDecimals: number, reduceLadder: boolean = true){
+    const parsedMarketOutcomeAccount = marketOutcomeAccount
+    parsedMarketOutcomeAccount.matchedTotal = parseTokenAmountBN(parsedMarketOutcomeAccount.matchedTotal, mintDecimals)
+        if(reduceLadder){
+            const ladderStart = [...parsedMarketOutcomeAccount.priceLadder.splice(0, 3)]
+            const ladderEnd = [...parsedMarketOutcomeAccount.priceLadder.splice(parsedMarketOutcomeAccount.priceLadder.length - 3, 3)]
+            parsedMarketOutcomeAccount.priceLadder = [...ladderStart, ...ladderEnd]
+        }
+    return parsedMarketOutcomeAccount
+}

--- a/examples/cli/src/parsers/market_parser.ts
+++ b/examples/cli/src/parsers/market_parser.ts
@@ -1,0 +1,11 @@
+import { BN } from "@project-serum/anchor";
+import { MarketAccount } from "@monaco-protocol/client";
+
+export function parseMarketAccount(market: MarketAccount){
+    market.marketLockTimestamp = market.marketLockTimestamp.toNumber()
+    if (market.marketSettleTimestamp){
+        const settleTimestamp = market.marketSettleTimestamp as BN
+        market.marketSettleTimestamp = settleTimestamp.toNumber()
+    }
+    return market
+}

--- a/examples/cli/src/parsers/market_position_parser.ts
+++ b/examples/cli/src/parsers/market_position_parser.ts
@@ -1,0 +1,12 @@
+import { parseTokenAmountBN } from "./token_parser";
+
+export function parseMarketPosition(marketPosition, mintDecimals: number){
+    marketPosition.marketOutcomeSums.forEach((outcomeSum, index) => {
+        marketPosition.marketOutcomeSums[index] = parseTokenAmountBN(outcomeSum, mintDecimals)
+    })
+    marketPosition.outcomeMaxExposure.forEach((outcomeMaxExposure, index) => {
+        marketPosition.outcomeMaxExposure[index] = parseTokenAmountBN(outcomeMaxExposure, mintDecimals)
+    })
+    marketPosition.offset = parseTokenAmountBN(marketPosition.offset, mintDecimals)
+    return marketPosition
+}

--- a/examples/cli/src/parsers/market_price_parser.ts
+++ b/examples/cli/src/parsers/market_price_parser.ts
@@ -1,0 +1,10 @@
+import { MarketPrice } from "@monaco-protocol/client"
+import { parseTokenAmountBN } from "./token_parser"
+
+export function parseMarketPrice(marketPrice: MarketPrice, mintDecimals: number, onlyShowOrdersInQueue: boolean = true){
+    const parsedMarketPrices = marketPrice
+    parsedMarketPrices.matchingPool.liquidityAmount = parseTokenAmountBN(parsedMarketPrices.matchingPool.liquidityAmount, mintDecimals)
+    parsedMarketPrices.matchingPool.matchedAmount = parseTokenAmountBN(parsedMarketPrices.matchingPool.matchedAmount, mintDecimals)
+    if (onlyShowOrdersInQueue) parsedMarketPrices.matchingPool.orders.items = parsedMarketPrices.matchingPool.orders.items.filter(order => order.toString() != "11111111111111111111111111111111")
+    return parsedMarketPrices
+}

--- a/examples/cli/src/parsers/market_prices_and_pending_orders.ts
+++ b/examples/cli/src/parsers/market_prices_and_pending_orders.ts
@@ -1,0 +1,19 @@
+import { MarketPricesAndPendingOrders } from "@monaco-protocol/client"
+import { parseMarketOutcomeAccount } from "./market_outcome_parser"
+import { parseMarketAccount } from "./market_parser"
+import { parseMarketPrice } from "./market_price_parser"
+import { parseOrderAccount } from "./order_parser"
+
+export function parseMarketPricesAndPendingOrders(marketPricesAndPendingOrders: MarketPricesAndPendingOrders, mintDecimals: number, reduceLadder: boolean = true, onlyShowOrdersInQueue: boolean = true){
+    marketPricesAndPendingOrders.market = parseMarketAccount(marketPricesAndPendingOrders.market)
+    marketPricesAndPendingOrders.marketOutcomeAccounts.map((marketOutcomeAccount) => {
+        marketOutcomeAccount.account = parseMarketOutcomeAccount(marketOutcomeAccount.account, mintDecimals, reduceLadder)
+    })
+    marketPricesAndPendingOrders.marketPrices.map((marketPrices) => {
+        marketPrices = parseMarketPrice(marketPrices, mintDecimals, onlyShowOrdersInQueue)
+    })
+    marketPricesAndPendingOrders.pendingOrders.map(order => {
+        order.account = parseOrderAccount(order.account, mintDecimals)
+    })
+    return marketPricesAndPendingOrders
+}

--- a/examples/cli/src/parsers/order_parser.ts
+++ b/examples/cli/src/parsers/order_parser.ts
@@ -1,0 +1,11 @@
+import { Order } from "@monaco-protocol/client"
+import { parseTokenAmountBN } from "./token_parser"
+
+export function parseOrderAccount(order: Order, mintDecimals: number){
+    order.creationTimestamp = order.creationTimestamp.toNumber()
+    order.payout =  parseTokenAmountBN(order.payout, mintDecimals)
+    order.stake = parseTokenAmountBN(order.stake, mintDecimals)
+    order.stakeUnmatched = parseTokenAmountBN(order.stakeUnmatched, mintDecimals)
+    order.voidedStake = parseTokenAmountBN(order.voidedStake, mintDecimals)
+    return order
+}

--- a/examples/cli/src/parsers/token_parser.ts
+++ b/examples/cli/src/parsers/token_parser.ts
@@ -1,0 +1,5 @@
+import { BN } from "@project-serum/anchor"
+
+export function parseTokenAmountBN(tokenAmount: BN, mintDecimals: number){
+    return tokenAmount.toNumber() / 10 ** mintDecimals
+}

--- a/examples/cli/src/parsers/trade_parser.ts
+++ b/examples/cli/src/parsers/trade_parser.ts
@@ -1,0 +1,8 @@
+import { Trade } from "@monaco-protocol/client";
+import { parseTokenAmountBN } from "./token_parser";
+
+export function parseTrade(trade: Trade, mintDecimals: number){
+    trade.creationTimestamp = trade.creationTimestamp.toNumber()
+    trade.stake = parseTokenAmountBN(trade.stake, mintDecimals)
+    return trade
+}


### PR DESCRIPTION
- Add parsing examples
- Add mapping examples
- Add new script `npm run getMarketSummary <marketPk>` which parses and organises the market prices response into something more human readable
- Add new script `npm run getOrdersForMarketByStatus` to get all orders for a market by status