### PR TITLE
Check operator role on market create create

### DIFF
--- a/examples/cli-admin/src/market_create.ts
+++ b/examples/cli-admin/src/market_create.ts
@@ -2,12 +2,17 @@ import { PublicKey, Keypair } from "@solana/web3.js";
 import {
   createMarketWithOutcomesAndPriceLadder,
   MarketType,
-  DEFAULT_PRICE_LADDER
+  DEFAULT_PRICE_LADDER,
+  checkOperatorRoles
 } from "@monaco-protocol/admin-client";
 import { getProgram, log, getProcessArgs, logResponse } from "./utils";
 
 async function createMarket(mintToken: PublicKey) {
   const program = await getProgram();
+  const checkRoles = await checkOperatorRoles(program, program.provider.publicKey)
+
+  if (!checkRoles.data.market) throw new Error(`Currently set wallet ${program.provider.publicKey} does not have the operator role`)
+
   // Generate a publicKey to represent the event
   const eventAccountKeyPair = Keypair.generate();
   const eventPk = eventAccountKeyPair.publicKey;

--- a/examples/cli-admin/src/market_create.ts
+++ b/examples/cli-admin/src/market_create.ts
@@ -9,9 +9,15 @@ import { getProgram, log, getProcessArgs, logResponse } from "./utils";
 
 async function createMarket(mintToken: PublicKey) {
   const program = await getProgram();
-  const checkRoles = await checkOperatorRoles(program, program.provider.publicKey)
+  const checkRoles = await checkOperatorRoles(
+    program,
+    program.provider.publicKey
+  );
 
-  if (!checkRoles.data.market) throw new Error(`Currently set wallet ${program.provider.publicKey} does not have the operator role`)
+  if (!checkRoles.data.market)
+    throw new Error(
+      `Currently set wallet ${program.provider.publicKey} does not have the operator role`
+    );
 
   // Generate a publicKey to represent the event
   const eventAccountKeyPair = Keypair.generate();

--- a/examples/cli-admin/src/market_create_verbose.ts
+++ b/examples/cli-admin/src/market_create_verbose.ts
@@ -5,12 +5,16 @@ import {
   DEFAULT_PRICE_LADDER,
   initialiseOutcomes,
   batchAddPricesToAllOutcomePools,
-  addPricesToOutcome
+  checkOperatorRoles
 } from "@monaco-protocol/admin-client";
 import { getProgram, log, getProcessArgs, logResponse } from "./utils";
 
 async function createVerboseMarket(mintToken: PublicKey) {
   const program = await getProgram();
+  const checkRoles = await checkOperatorRoles(program, program.provider.publicKey)
+
+  if (!checkRoles.data.market) throw new Error(`Currently set wallet ${program.provider.publicKey} does not have the operator role`)
+
   // Generate a publicKey to represent the event
   const eventAccountKeyPair = Keypair.generate();
   const eventPk = eventAccountKeyPair.publicKey;

--- a/examples/cli-admin/src/market_create_verbose.ts
+++ b/examples/cli-admin/src/market_create_verbose.ts
@@ -11,9 +11,15 @@ import { getProgram, log, getProcessArgs, logResponse } from "./utils";
 
 async function createVerboseMarket(mintToken: PublicKey) {
   const program = await getProgram();
-  const checkRoles = await checkOperatorRoles(program, program.provider.publicKey)
+  const checkRoles = await checkOperatorRoles(
+    program,
+    program.provider.publicKey
+  );
 
-  if (!checkRoles.data.market) throw new Error(`Currently set wallet ${program.provider.publicKey} does not have the operator role`)
+  if (!checkRoles.data.market)
+    throw new Error(
+      `Currently set wallet ${program.provider.publicKey} does not have the operator role`
+    );
 
   // Generate a publicKey to represent the event
   const eventAccountKeyPair = Keypair.generate();


### PR DESCRIPTION
- Before attempting to create a market, check if the supplied wallet has the operator role
- If not, throw and error as the market cannot be created