### PR TITLE
fix: remove offset from market position

### DIFF
--- a/examples/cli/src/parsers/market_position_parser.ts
+++ b/examples/cli/src/parsers/market_position_parser.ts
@@ -1,6 +1,7 @@
+import { MarketPosition } from "@monaco-protocol/client";
 import { parseTokenAmountBN } from "./token_parser";
 
-export function parseMarketPosition(marketPosition, mintDecimals: number) {
+export function parseMarketPosition(marketPosition: MarketPosition, mintDecimals: number) {
   marketPosition.marketOutcomeSums.forEach((outcomeSum, index) => {
     marketPosition.marketOutcomeSums[index] = parseTokenAmountBN(
       outcomeSum,
@@ -13,9 +14,5 @@ export function parseMarketPosition(marketPosition, mintDecimals: number) {
       mintDecimals
     );
   });
-  marketPosition.offset = parseTokenAmountBN(
-    marketPosition.offset,
-    mintDecimals
-  );
   return marketPosition;
 }


### PR DESCRIPTION
- As of `0.8.0` offset is no longer returned on market position
- Removing from the parser