### PR TITLE
chore: update example product to 0% product set up on mainnet

### DIFF
--- a/examples/cli/src/products/create_product.ts
+++ b/examples/cli/src/products/create_product.ts
@@ -4,8 +4,8 @@ import { parseResponseData } from "../parsers/parsers";
 
 async function newProduct() {
   const program = await getProgram(ProtocolTypes.MONACO_PRODUCT);
-  const productTitle = "MONACO_PROTOCOL_SDK";
-  const commissionRate = 1.23;
+  const productTitle = "SDK_EXAMPLE_PRODUCT";
+  const commissionRate = 0;
   const commissionEscrow = program.provider.publicKey;
   const response = await createProduct(program, productTitle, commissionRate, commissionEscrow);
   response.data = parseResponseData(response.data)

--- a/examples/cli/src/products/update_product_auth.ts
+++ b/examples/cli/src/products/update_product_auth.ts
@@ -7,7 +7,7 @@ import NodeWallet from "@coral-xyz/anchor/dist/cjs/nodewallet";
 async function updateAuth() {
   const program = await getProgram(ProtocolTypes.MONACO_PRODUCT);
   const provider = program.provider as AnchorProvider;
-  const productTitle = "MONACO_PROTOCOL_SDK";
+  const productTitle = "SDK_EXAMPLE_PRODUCT";
   const authorityPk = program.provider.publicKey;
   // Setting as the same signer for example purposes
   const newAuthority = (provider.wallet as NodeWallet).payer

--- a/examples/cli/src/products/update_product_escrow.ts
+++ b/examples/cli/src/products/update_product_escrow.ts
@@ -4,7 +4,7 @@ import { parseResponseData } from "../parsers/parsers";
 
 async function updateEscrow() {
   const program = await getProgram(ProtocolTypes.MONACO_PRODUCT);
-  const productTitle = "MONACO_PROTOCOL_SDK";
+  const productTitle = "SDK_EXAMPLE_PRODUCT";
   const authorityPk = program.provider.publicKey;
   // Setting as the same Pk as this is just for example purposes
   const newEscrowPk = program.provider.publicKey;

--- a/examples/cli/src/products/update_product_rate.ts
+++ b/examples/cli/src/products/update_product_rate.ts
@@ -4,7 +4,7 @@ import { parseResponseData } from "../parsers/parsers";
 
 async function updateRate(newRate: number) {
   const program = await getProgram(ProtocolTypes.MONACO_PRODUCT);
-  const productTitle = "MONACO_PROTOCOL_SDK";
+  const productTitle = "SDK_EXAMPLE_PRODUCT";
   const authorityPk = program.provider.publicKey;
   const response = await updateProductCommissionRate(program, productTitle, newRate, authorityPk);
   response.data = parseResponseData(response.data)

--- a/examples/cli/src/utils/utils.ts
+++ b/examples/cli/src/utils/utils.ts
@@ -100,7 +100,9 @@ export function getProcessArgs(
   return values;
 }
 
-export const SDK_PRODUCT = new PublicKey('bwCvZn6Hs4v51tvwFdAtAyJXzLddjgUMnQn2SehXmhF')
+// 0% commission rate product on devnet and mainnet
+// https://explorer.solana.com/address/DVG5jXTzAh7aN6Ekm1cd2dQkEcAP3hJvcibp8eqLwCkz/anchor-account
+export const SDK_PRODUCT = new PublicKey('DVG5jXTzAh7aN6Ekm1cd2dQkEcAP3hJvcibp8eqLwCkz')
 
 export function marketStatusFromString(status: string) {
   switch (status) {


### PR DESCRIPTION
The SDK entry examples pass through a product key, this updates that product key to be a 0% commission product named `SDK_EXAMPLE_PRODUCT` on both `devnet` and `mainnet`.

Any references to product title in examples have been changed to `SDK_EXAMPLE_PRODUCT`.

- https://explorer.solana.com/address/DVG5jXTzAh7aN6Ekm1cd2dQkEcAP3hJvcibp8eqLwCkz/anchor-account
- https://explorer.solana.com/address/DVG5jXTzAh7aN6Ekm1cd2dQkEcAP3hJvcibp8eqLwCkz/anchor-account?cluster=devnet