### PR TITLE
docs: example get market status count script

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -19,6 +19,7 @@
     "getMarketPositions": "ts-node src/markets/get_market_positions.ts",
     "getMarketAccounts": "ts-node src/markets/get_market_accounts.ts",
     "getMarketSummary": "ts-node src/markets/get_market_summary.ts",
+    "getMarketStatusCount": "ts-node src/markets/get_market_status_count.ts",
     "getMarketOutcomeAccounts": "ts-node src/markets/get_market_outcomes.ts",
     "getMarketPriceLadder": "ts-node src/markets/get_market_price_ladder.ts",
     "getTradesForMarket": "ts-node src/trades/get_trades_for_market.ts",

--- a/examples/cli/src/markets/get_market_status_count.ts
+++ b/examples/cli/src/markets/get_market_status_count.ts
@@ -1,0 +1,30 @@
+import { MarketStatusFilter, Markets } from "@monaco-protocol/client";
+import { getProcessArgs, getProgram } from "../utils/utils";
+
+const getStatusCount = async () => {
+  const program = await getProgram();
+  const statuses = [
+    MarketStatusFilter.Initializing,
+    MarketStatusFilter.Open,
+    MarketStatusFilter.Settled,
+    MarketStatusFilter.Voided,
+    MarketStatusFilter.ReadyForSettlement,
+    MarketStatusFilter.ReadyToVoid,
+    MarketStatusFilter.ReadyToClose
+  ];
+  const allStatuses = [];
+  for (const marketStatus of statuses) {
+    const markets = await Markets.marketQuery(program)
+      .filterByStatus(marketStatus)
+      .fetch();
+
+    allStatuses.push({
+      status: MarketStatusFilter[marketStatus],
+      count: markets.data.markets.length
+    });
+  }
+  console.table(allStatuses);
+};
+
+getProcessArgs([], "npm run getMarketStatusCount");
+getStatusCount();


### PR DESCRIPTION
- Example script to list the count of markets on the protocol by status

![image](https://github.com/MonacoProtocol/sdk/assets/11299576/e6e57111-222e-4ce7-9bc3-12345d675357)
