### PR TITLE
fix: optimise market count script

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -19,7 +19,7 @@
     "getMarketPositions": "ts-node src/markets/get_market_positions.ts",
     "getMarketAccounts": "ts-node src/markets/get_market_accounts.ts",
     "getMarketSummary": "ts-node src/markets/get_market_summary.ts",
-    "getMarketStatusCount": "ts-node src/markets/get_market_status_count.ts",
+    "getMarketCount": "ts-node src/markets/get_market_status_count.ts",
     "getMarketOutcomeAccounts": "ts-node src/markets/get_market_outcomes.ts",
     "getMarketPriceLadder": "ts-node src/markets/get_market_price_ladder.ts",
     "getTradesForMarket": "ts-node src/trades/get_trades_for_market.ts",

--- a/examples/cli/src/markets/get_market_status_count.ts
+++ b/examples/cli/src/markets/get_market_status_count.ts
@@ -13,18 +13,18 @@ const getStatusCount = async () => {
     MarketStatusFilter.ReadyToClose
   ];
   const statusPromises = statuses.map((status) =>
-    Markets.marketQuery(program).filterByStatus(status).fetch()
+    Markets.marketQuery(program).filterByStatus(status).fetchPublicKeys()
   );
   const resolvePromises = await Promise.all(statusPromises);
   const allStatuses = [];
   for (const marketStatus of statuses) {
     allStatuses.push({
       status: MarketStatusFilter[marketStatus],
-      count: resolvePromises[statuses.indexOf(marketStatus)].data.markets.length
+      count: resolvePromises[statuses.indexOf(marketStatus)].data.publicKeys.length
     });
   }
   console.table(allStatuses);
 };
 
-getProcessArgs([], "npm run getMarketStatusCount");
+getProcessArgs([], "npm run getMarketCount");
 getStatusCount();


### PR DESCRIPTION
- Only query public keys
- Adjust script invocation to `npm run getMarketCount`