### PR TITLE
Docs/mp for wallet

### DIFF
--- a/examples/cli/package.json
+++ b/examples/cli/package.json
@@ -16,6 +16,7 @@
     "getMarketOutcomeTitles": "ts-node src/markets/get_market_outcome_titles.ts",
     "getMarketPosition": "ts-node src/markets/get_market_position.ts",
     "getMarketPositions": "ts-node src/markets/get_market_positions.ts",
+    "getMarketPositionsForWallet": "ts-node src/markets/get_market_positions_for_wallet.ts",
     "getMarketAccounts": "ts-node src/markets/get_market_accounts.ts",
     "getMarketSummary": "ts-node src/markets/get_market_summary.ts",
     "getMarketCount": "ts-node src/markets/get_market_status_count.ts",

--- a/examples/cli/src/markets/get_market_positions_for_wallet.ts
+++ b/examples/cli/src/markets/get_market_positions_for_wallet.ts
@@ -1,0 +1,40 @@
+import { MarketPositions, getMarketOutcomeTitlesByMarket } from "@monaco-protocol/client";
+import { PublicKey } from "@solana/web3.js";
+import { getProgram, getProcessArgs, logResponse } from "../utils/utils";
+import { AnchorProvider } from "@coral-xyz/anchor";
+import { parseResponseData } from "../parsers/parsers";
+
+async function getMarketPositionForProvider(walletPk: PublicKey) {
+  const program = await getProgram();
+  const provider = program.provider as AnchorProvider;
+  const response = await MarketPositions.marketPositionQuery(program)
+    .filterByPurchaser(walletPk)
+    .filterByPaid(false)
+    .fetch();
+  response.data = parseResponseData(response.data, 6);
+  const positions = {};
+  for (const position of response.data.marketPositionAccounts) {
+    const outcomeTitles = await getMarketOutcomeTitlesByMarket(program, position.account.market);
+    const matchedPosition = position.account.marketOutcomeSums.map((exposure, index) => {
+      return {
+        outcome: outcomeTitles.data.marketOutcomeTitles[index],
+        exposure: exposure,
+        unmatched: position.account.unmatchedExposures[index]
+      }
+    });
+
+    positions[position.account.market.toBase58()] = {
+      position: matchedPosition,
+    }
+  }
+  for (const market in positions) {
+    console.log(`Market: ${market}`);
+    console.table(positions[market].position);
+  }
+}
+
+const args = getProcessArgs(
+  ["walletPk"],
+  "npm run getMarketPositionsForWallet"
+);
+getMarketPositionForProvider(new PublicKey(args.walletPk));

--- a/examples/cli/src/markets/get_market_positions_for_wallet.ts
+++ b/examples/cli/src/markets/get_market_positions_for_wallet.ts
@@ -1,10 +1,10 @@
 import { MarketPositions, getMarketOutcomeTitlesByMarket } from "@monaco-protocol/client";
 import { PublicKey } from "@solana/web3.js";
-import { getProgram, getProcessArgs, logResponse } from "../utils/utils";
+import { getProgram, getProcessArgs } from "../utils/utils";
 import { AnchorProvider } from "@coral-xyz/anchor";
 import { parseResponseData } from "../parsers/parsers";
 
-async function getMarketPositionForProvider(walletPk: PublicKey) {
+async function getMarketPositionForWallet(walletPk: PublicKey) {
   const program = await getProgram();
   const provider = program.provider as AnchorProvider;
   const response = await MarketPositions.marketPositionQuery(program)
@@ -37,4 +37,4 @@ const args = getProcessArgs(
   ["walletPk"],
   "npm run getMarketPositionsForWallet"
 );
-getMarketPositionForProvider(new PublicKey(args.walletPk));
+getMarketPositionForWallet(new PublicKey(args.walletPk));


### PR DESCRIPTION
- Example to get `unpaid` market positions for a wallet
- Gets position, gets outcome titles for each market position, outputs tabled result

![image](https://github.com/user-attachments/assets/d6c56a00-e740-4129-abd7-b09f3fc7124d)
